### PR TITLE
Fix method UserAgentClientMinorVersion

### DIFF
--- a/src/NuGet.Warehouse/dbo/Functions/UserAgentClientMajorVersion.sql
+++ b/src/NuGet.Warehouse/dbo/Functions/UserAgentClientMajorVersion.sql
@@ -29,7 +29,10 @@ BEGIN
         -- If there is no minor version (i.e, no dot in the client version, the following method will throw)
         RETURN CAST(SUBSTRING(
             @value, 
+            -- Start 1 character after the /
             CHARINDEX('/', @value) + 1,
+            -- To determine string length, subtract (position of first slash, determined as above) from
+            -- (Position of first dot occuring after first slash)
             CHARINDEX('.', @value, CHARINDEX('/', @value) + 1) - (CHARINDEX('/', @value) + 1)
         ) AS INT)
 

--- a/src/NuGet.Warehouse/dbo/Functions/UserAgentClientMinorVersion.sql
+++ b/src/NuGet.Warehouse/dbo/Functions/UserAgentClientMinorVersion.sql
@@ -32,10 +32,18 @@ BEGIN
         IF  (CHARINDEX('(', @value) != 0) SET	@value = SUBSTRING(@value, 0, CHARINDEX('(', @value))
         RETURN CAST(SUBSTRING(
                 @value, 
+                -- Start 1 character after the first dot after the /
                 CHARINDEX('.', @value, CHARINDEX('/', @value) + 1) + 1, 
-                (CHARINDEX('.', CONCAT(@value, '.'), CHARINDEX('.', @value, CHARINDEX('/', @value) + 1) + 1)) - ((CHARINDEX('.', @value, CHARINDEX('/', @value) + 1)) + 1)
+                -- And determine our string length
+                (
+                    -- CONCAT: Add a dot to the end to make sure we can find a dot
+                    -- Find the position of the next dot, starting 1 character after the first dot after the / (like we did above)
+                    CHARINDEX('.', CONCAT(@value, '.'), CHARINDEX('.', @value, CHARINDEX('/', @value) + 1) + 1))
+                    -- And now subtract the starting point we used to get the length of the string
+                    - ((CHARINDEX('.', @value, CHARINDEX('/', @value) + 1)) + 1
+                )
             ) AS INT)
-	END
+    END
 
     RETURN 0
 END


### PR DESCRIPTION
Fix UserAgentClientMinorVersion. UserAgent may not always have the patchversion. So, need to parse for minor version slightly differently.
Only added comments to function 'UserAgentClientMajorVersion'

Ran the following tests

DECLARE     @UserAgent1 nvarchar(4000) = 'NuGet Command Line/2.8.4 (Microsoft Windows NT 6.3.9600.0)'
DECLARE     @UserAgent2 nvarchar(4000) = 'NuGet Command Line/2.8 '
DECLARE     @UserAgent3 nvarchar(4000) = 'NuGet Command Line/2.8 (Microsoft Windows NT 6.3.9600.0)'
DECLARE     @UserAgent4 nvarchar(4000) = 'NuGet Command Line/2.8'

SELECT      [dbo].[UserAgentClientMinorVersion-Test](@UserAgent1)
SELECT      [dbo].[UserAgentClientMinorVersion-Test](@UserAgent2)
SELECT      [dbo].[UserAgentClientMinorVersion-Test](@UserAgent3)
SELECT      [dbo].[UserAgentClientMinorVersion-Test](@UserAgent4)

SELECT      [dbo].[UserAgentClientMajorVersion-Test](@UserAgent1)
SELECT      [dbo].[UserAgentClientMajorVersion-Test](@UserAgent2)
SELECT      [dbo].[UserAgentClientMajorVersion-Test](@UserAgent3)
SELECT      [dbo].[UserAgentClientMajorVersion-Test](@UserAgent4)
