### PR TITLE
Added Cake user agent client

### DIFF
--- a/src/NuGet.Warehouse/dbo/Functions/UserAgentClient.sql
+++ b/src/NuGet.Warehouse/dbo/Functions/UserAgentClient.sql
@@ -74,5 +74,9 @@ BEGIN
     IF CHARINDEX('Paket', @value) > 0
         RETURN 'Paket'
 
+	-- Refer to https://cakebuild.net for details
+    IF CHARINDEX('Cake', @value) > 0
+        RETURN 'Cake'
+
     RETURN 'Other'
 END


### PR DESCRIPTION
Since Cake [v0.24.0](https://github.com/cake-build/cake/releases/tag/v0.24.0) in process NuGet handling now has a "Cake NuGet Client" user agent, so those downloads now incorrectly falls under _"unknown"_ client.