### PR TITLE
Inform repository obsolete in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NuGet.Warehouse
 
+**This repository has been made obsolete in favor of [NuGet/NuGet.Jobs](https://github.com/NuGet/NuGet.Jobs).**
+
 This repo contains NuGet's data warehouse for NuGet Gallery package downloads.
 
 ## Open Source Code of Conduct


### PR DESCRIPTION
@xavierdecoster is is a fair statement to say: "This repository has been made obsolete in favor of [NuGet/NuGet.Jobs](https://github.com/NuGet/NuGet.Jobs)."

If that's the case I propose with this PR we add a notice about that in the README and also suggest you archive this repository, which puts it in a readonly state to avoid future confusion.
![image](https://user-images.githubusercontent.com/1647294/34715293-5baf312c-f52c-11e7-864e-857f0af1b3fc.png)
